### PR TITLE
Add client-side organizational chart explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# Organizational-chart
+# Organizational Chart Explorer
+
+A lightweight, client-side web app for visualizing an organization's structure from an Excel workbook or Google Sheets link. Switch between tribe-based and manager-based views, search across employee attributes, and navigate large hierarchies with a built-in mini map and zoom controls.
+
+## Getting started
+
+1. Open `index.html` in your browser. No build tools are required.
+2. Upload an `.xlsx` file or paste a Google Sheets share link with columns for:
+   - Employee name
+   - Tribe
+   - Squad
+   - Expertise
+   - Job level
+   - Manager name
+3. Use the view toggle to switch between tribe and manager views.
+4. Use the search bar to filter by any employee attribute.
+5. Explore the chart with the floating controls (expand/collapse, zoom, and zoom-to-fit) or the minimap.
+
+A curated sample dataset is loaded automatically so you can try the interface immediately. Click **Use sample data** to restore the sample if needed.
+
+## Development notes
+
+- All processing happens in the browser using [SheetJS](https://sheetjs.com/) via CDN to parse Excel files.
+- Google Sheets links are converted to CSV via the public export endpoint. Ensure the sheet is shared accordingly.
+- The layout is computed on the fly with a simple tree layout algorithm; no external frameworks are required.
+
+Feel free to customize the styling in `styles.css` or extend the rendering logic in `app.js` to suit your organization.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,970 @@
+const NODE_WIDTH = 220;
+const NODE_HEIGHT = 120;
+const HORIZONTAL_GAP = 260;
+const VERTICAL_GAP = 200;
+const MIN_SCALE = 0.4;
+const MAX_SCALE = 2.4;
+const SCALE_STEP = 0.15;
+
+const COLUMN_ALIASES = {
+  name: ["employee name", "name", "full name"],
+  tribe: ["tribe", "chapter", "department", "group"],
+  squad: ["squad", "team", "unit"],
+  expertise: ["expertise", "role", "function", "speciality", "specialty"],
+  level: ["job level", "level", "grade"],
+  manager: ["manager name", "manager", "reporting to", "reports to"],
+};
+
+const SAMPLE_DATA = [
+  {
+    name: "Aria Chen",
+    tribe: "Product",
+    squad: "Discovery",
+    expertise: "Product Manager",
+    level: "Senior",
+    manager: "Daniel Rivera",
+  },
+  {
+    name: "Jonas Patel",
+    tribe: "Product",
+    squad: "Discovery",
+    expertise: "UX Researcher",
+    level: "Mid",
+    manager: "Aria Chen",
+  },
+  {
+    name: "Lila Mensah",
+    tribe: "Product",
+    squad: "Discovery",
+    expertise: "Product Designer",
+    level: "Mid",
+    manager: "Aria Chen",
+  },
+  {
+    name: "Mateo García",
+    tribe: "Product",
+    squad: "Growth",
+    expertise: "Product Manager",
+    level: "Lead",
+    manager: "Daniel Rivera",
+  },
+  {
+    name: "Sofia Novak",
+    tribe: "Engineering",
+    squad: "Growth",
+    expertise: "Frontend Engineer",
+    level: "Mid",
+    manager: "Mateo García",
+  },
+  {
+    name: "Emily Stone",
+    tribe: "Engineering",
+    squad: "Growth",
+    expertise: "Backend Engineer",
+    level: "Senior",
+    manager: "Mateo García",
+  },
+  {
+    name: "Kai Nakamura",
+    tribe: "Engineering",
+    squad: "Platform",
+    expertise: "DevOps Engineer",
+    level: "Senior",
+    manager: "Priya Desai",
+  },
+  {
+    name: "Priya Desai",
+    tribe: "Engineering",
+    squad: "Platform",
+    expertise: "Engineering Manager",
+    level: "Lead",
+    manager: "Daniel Rivera",
+  },
+  {
+    name: "Daniel Rivera",
+    tribe: "Executive",
+    squad: "Leadership",
+    expertise: "VP of Product & Engineering",
+    level: "Executive",
+    manager: "",
+  },
+  {
+    name: "Noah Jensen",
+    tribe: "People",
+    squad: "Operations",
+    expertise: "People Partner",
+    level: "Senior",
+    manager: "Daniel Rivera",
+  },
+  {
+    name: "Amelia Fox",
+    tribe: "People",
+    squad: "Operations",
+    expertise: "Recruiter",
+    level: "Mid",
+    manager: "Noah Jensen",
+  },
+];
+
+const state = {
+  rows: [],
+  view: "tribe",
+  collapsed: new Set(),
+  search: "",
+  scale: 1,
+  layout: null,
+};
+
+const elements = {
+  viewToggle: document.getElementById("view-toggle"),
+  themeToggle: document.getElementById("theme-toggle"),
+  fileInput: document.getElementById("file-input"),
+  sheetUrl: document.getElementById("sheet-url"),
+  loadSheet: document.getElementById("load-sheet"),
+  loadSample: document.getElementById("load-sample"),
+  searchInput: document.getElementById("search-input"),
+  clearSearch: document.getElementById("clear-search"),
+  chartContainer: document.getElementById("chart-container"),
+  chartContent: document.getElementById("chart-content"),
+  chartZoom: document.getElementById("chart-zoom"),
+  chartLinks: document.getElementById("chart-links"),
+  chartNodes: document.getElementById("chart-nodes"),
+  minimap: document.getElementById("minimap"),
+  emptyState: document.getElementById("empty-state"),
+  statusBar: document.getElementById("status-bar"),
+  statusMessage: document.getElementById("status-message"),
+  fab: document.getElementById("fab"),
+};
+
+const themePreference = localStorage.getItem("org-nav-theme");
+if (themePreference) {
+  document.documentElement.setAttribute("data-theme", themePreference);
+  updateThemeButton(themePreference);
+}
+
+elements.themeToggle.addEventListener("click", () => {
+  const current = document.documentElement.getAttribute("data-theme") || "light";
+  const next = current === "light" ? "dark" : "light";
+  document.documentElement.setAttribute("data-theme", next);
+  localStorage.setItem("org-nav-theme", next);
+  updateThemeButton(next);
+});
+
+elements.viewToggle.addEventListener("change", () => {
+  state.view = elements.viewToggle.checked ? "manager" : "tribe";
+  state.collapsed.clear();
+  render();
+});
+
+elements.fileInput.addEventListener("change", async (event) => {
+  const file = event.target.files?.[0];
+  if (!file) return;
+  try {
+    updateStatus(`Loading ${file.name}…`);
+    const buffer = await file.arrayBuffer();
+    const workbook = XLSX.read(buffer, { type: "array" });
+    const sheetName = workbook.SheetNames[0];
+    if (!sheetName) throw new Error("No sheets detected in the workbook");
+    const worksheet = workbook.Sheets[sheetName];
+    const rawRows = XLSX.utils.sheet_to_json(worksheet, { defval: "" });
+    state.rows = mapRows(rawRows);
+    state.collapsed.clear();
+    state.search = "";
+    elements.searchInput.value = "";
+    render();
+    updateStatus(`Loaded ${state.rows.length} rows from ${sheetName}`);
+  } catch (error) {
+    console.error(error);
+    updateStatus(`Failed to load spreadsheet: ${error.message}`, true);
+  } finally {
+    event.target.value = "";
+  }
+});
+
+elements.loadSheet.addEventListener("click", async () => {
+  const url = elements.sheetUrl.value.trim();
+  if (!url) {
+    updateStatus("Please paste a Google Sheets URL", true);
+    return;
+  }
+  const sheetId = extractGoogleSheetId(url);
+  if (!sheetId) {
+    updateStatus("Could not parse the Google Sheets link", true);
+    return;
+  }
+  try {
+    updateStatus("Fetching Google Sheet…");
+    const response = await fetch(
+      `https://docs.google.com/spreadsheets/d/${sheetId}/gviz/tq?tqx=out:csv`
+    );
+    if (!response.ok) {
+      throw new Error(`Google Sheets request failed (${response.status})`);
+    }
+    const csvText = await response.text();
+    const rows = parseCsv(csvText);
+    state.rows = mapRows(rows);
+    state.collapsed.clear();
+    state.search = "";
+    elements.searchInput.value = "";
+    render();
+    updateStatus(`Loaded ${state.rows.length} rows from Google Sheets`);
+  } catch (error) {
+    console.error(error);
+    updateStatus(`Failed to fetch Google Sheets data: ${error.message}`, true);
+  }
+});
+
+elements.loadSample.addEventListener("click", () => {
+  state.rows = [...SAMPLE_DATA];
+  state.collapsed.clear();
+  state.search = "";
+  elements.searchInput.value = "";
+  render();
+  updateStatus("Loaded sample organization data");
+});
+
+elements.searchInput.addEventListener("input", (event) => {
+  state.search = event.target.value.trim();
+  render();
+});
+
+elements.clearSearch.addEventListener("click", () => {
+  if (!state.search) return;
+  state.search = "";
+  elements.searchInput.value = "";
+  render();
+});
+
+elements.fab.addEventListener("click", (event) => {
+  const button = event.target.closest(".fab-button");
+  if (!button) return;
+  const action = button.dataset.action;
+  switch (action) {
+    case "zoom-in":
+      setScale(state.scale + SCALE_STEP);
+      break;
+    case "zoom-out":
+      setScale(state.scale - SCALE_STEP);
+      break;
+    case "zoom-fit":
+      zoomToFit();
+      break;
+    case "expand":
+      state.collapsed.clear();
+      render();
+      break;
+    case "collapse":
+      collapseAll();
+      break;
+    default:
+      break;
+  }
+});
+
+elements.chartContainer.addEventListener("scroll", () => {
+  drawMinimap(state.layout);
+});
+
+window.addEventListener("resize", () => {
+  drawMinimap(state.layout);
+});
+
+elements.minimap.addEventListener("click", (event) => {
+  if (!state.layout) return;
+  const { widthPx, heightPx } = state.layout;
+  if (!widthPx || !heightPx) return;
+
+  const rect = elements.minimap.getBoundingClientRect();
+  const x = event.clientX - rect.left;
+  const y = event.clientY - rect.top;
+
+  const { scale, offsetX, offsetY } = getMinimapScaling(widthPx, heightPx);
+  const chartX = (x - offsetX) / scale;
+  const chartY = (y - offsetY) / scale;
+
+  const targetX = chartX * state.scale - elements.chartContainer.clientWidth / 2;
+  const targetY = chartY * state.scale - elements.chartContainer.clientHeight / 2;
+  elements.chartContainer.scrollTo({
+    left: clamp(targetX, 0, elements.chartContainer.scrollWidth),
+    top: clamp(targetY, 0, elements.chartContainer.scrollHeight),
+    behavior: "smooth",
+  });
+});
+
+function setScale(next) {
+  const clamped = clamp(next, MIN_SCALE, MAX_SCALE);
+  if (Math.abs(clamped - state.scale) < 0.001) return;
+  state.scale = clamped;
+  render();
+}
+
+function zoomToFit() {
+  if (!state.layout) return;
+  const containerWidth = elements.chartContainer.clientWidth;
+  const containerHeight = elements.chartContainer.clientHeight;
+  if (containerWidth === 0 || containerHeight === 0) return;
+
+  const { widthPx, heightPx } = state.layout;
+  if (!widthPx || !heightPx) return;
+
+  const scaleX = containerWidth / widthPx;
+  const scaleY = containerHeight / heightPx;
+  const nextScale = clamp(Math.min(scaleX, scaleY) * 0.92, MIN_SCALE, MAX_SCALE);
+  state.scale = nextScale;
+  render();
+}
+
+function collapseAll() {
+  const tree = buildTree();
+  const ids = [];
+  const collect = (node) => {
+    if (node.children?.length) {
+      ids.push(node.id);
+      node.children.forEach(collect);
+    }
+  };
+  tree.forEach(collect);
+  state.collapsed = new Set(ids);
+  render();
+}
+
+function render() {
+  if (!state.rows.length) {
+    elements.chartNodes.innerHTML = "";
+    elements.chartLinks.innerHTML = "";
+    state.layout = null;
+    elements.emptyState.style.display = "flex";
+    drawMinimap(null);
+    return;
+  }
+
+  const tree = buildTree();
+  const filteredTree = applySearch(tree, state.search);
+  const layout = computeLayout(filteredTree);
+  state.layout = layout;
+
+  renderLinks(layout);
+  renderNodes(layout);
+  elements.emptyState.style.display = "none";
+  drawMinimap(layout);
+}
+
+function buildTree() {
+  return state.view === "manager"
+    ? buildManagerTree(state.rows)
+    : buildTribeTree(state.rows);
+}
+
+function buildManagerTree(rows) {
+  const employeeNodes = [];
+  const employeesByName = new Map();
+  const placeholderManagers = new Map();
+
+  rows.forEach((row, index) => {
+    const label = row.name || `Employee ${index + 1}`;
+    const node = {
+      id: `emp-${index}`,
+      key: `${label}-${index}`,
+      label,
+      type: "employee",
+      data: row,
+      children: [],
+      originalChildren: [],
+      collapsed: false,
+      hasChildren: false,
+      isMatch: false,
+      visible: true,
+      searchTerms: buildSearchTerms(row, label),
+    };
+    employeeNodes.push(node);
+    const list = employeesByName.get(label) || [];
+    list.push(node);
+    employeesByName.set(label, list);
+  });
+
+  const getManagerNode = (name) => {
+    if (!name) return null;
+    const trimmed = name.trim();
+    if (!trimmed) return null;
+    const employeeList = employeesByName.get(trimmed);
+    if (employeeList && employeeList.length) {
+      return employeeList[0];
+    }
+    if (!placeholderManagers.has(trimmed)) {
+      const placeholder = {
+        id: `placeholder-${placeholderManagers.size}`,
+        key: trimmed,
+        label: trimmed,
+        type: "placeholder",
+        data: {
+          name: trimmed,
+          tribe: "",
+          squad: "",
+          expertise: "",
+          level: "",
+          manager: "",
+        },
+        children: [],
+        originalChildren: [],
+        collapsed: false,
+        hasChildren: false,
+        isMatch: false,
+        visible: true,
+        searchTerms: buildSearchTerms({ name: trimmed }, trimmed),
+      };
+      placeholderManagers.set(trimmed, placeholder);
+    }
+    return placeholderManagers.get(trimmed);
+  };
+
+  const roots = [];
+
+  employeeNodes.forEach((node) => {
+    const managerName = node.data.manager?.trim();
+    if (!managerName) {
+      roots.push(node);
+      return;
+    }
+    const managerNode = getManagerNode(managerName);
+    if (!managerNode) {
+      roots.push(node);
+      return;
+    }
+    if (managerNode === node) {
+      roots.push(node);
+      return;
+    }
+    managerNode.children.push(node);
+    node.parent = managerNode;
+  });
+
+  placeholderManagers.forEach((node) => {
+    if (!node.parent) {
+      roots.push(node);
+    }
+  });
+
+  const collapsedSet = state.search ? new Set() : state.collapsed;
+  const finalize = (node) => {
+    node.originalChildren = [...node.children];
+    node.hasChildren = node.originalChildren.length > 0;
+    if (collapsedSet.has(node.id)) {
+      node.children = [];
+      node.collapsed = true;
+    } else {
+      node.children = node.originalChildren.map(finalize);
+      node.collapsed = false;
+    }
+    return node;
+  };
+
+  return roots.map(finalize);
+}
+
+function buildTribeTree(rows) {
+  const tribeMap = new Map();
+
+  const getTribeNode = (tribeName) => {
+    const key = tribeName || "Unassigned Tribe";
+    if (!tribeMap.has(key)) {
+      tribeMap.set(key, {
+        id: `tribe-${key}`,
+        key,
+        label: key,
+        type: "tribe",
+        data: { tribe: key },
+        children: [],
+        originalChildren: [],
+        collapsed: false,
+        hasChildren: false,
+        isMatch: false,
+        visible: true,
+        searchTerms: buildSearchTerms({ tribe: key }, key),
+      });
+    }
+    return tribeMap.get(key);
+  };
+
+  const squadMap = new Map();
+  const getSquadNode = (tribeNode, squadName) => {
+    const key = `${tribeNode.key}__${squadName || "Unassigned Squad"}`;
+    if (!squadMap.has(key)) {
+      const label = squadName || "Unassigned Squad";
+      const node = {
+        id: `squad-${key}`,
+        key,
+        label,
+        type: "squad",
+        data: { tribe: tribeNode.label, squad: label },
+        children: [],
+        originalChildren: [],
+        collapsed: false,
+        hasChildren: false,
+        isMatch: false,
+        visible: true,
+        searchTerms: buildSearchTerms({ tribe: tribeNode.label, squad: label }, label),
+      };
+      squadMap.set(key, node);
+      tribeNode.children.push(node);
+      node.parent = tribeNode;
+    }
+    return squadMap.get(key);
+  };
+
+  rows.forEach((row) => {
+    const tribeNode = getTribeNode(row.tribe);
+    const squadNode = getSquadNode(tribeNode, row.squad);
+    const employeeNode = {
+      id: `emp-${row.name || crypto.randomUUID?.() || Math.random()}`,
+      key: row.name || Math.random().toString(36).slice(2),
+      label: row.name || "Unnamed",
+      type: "employee",
+      data: row,
+      children: [],
+      originalChildren: [],
+      collapsed: false,
+      hasChildren: false,
+      isMatch: false,
+      visible: true,
+      searchTerms: buildSearchTerms(row, row.name || "Unnamed"),
+      parent: squadNode,
+    };
+    squadNode.children.push(employeeNode);
+  });
+
+  const collapsedSet = state.search ? new Set() : state.collapsed;
+  const finalize = (node) => {
+    node.originalChildren = [...node.children];
+    node.hasChildren = node.originalChildren.length > 0;
+    if (collapsedSet.has(node.id)) {
+      node.children = [];
+      node.collapsed = true;
+    } else {
+      node.children = node.originalChildren.map(finalize);
+      node.collapsed = false;
+    }
+    return node;
+  };
+
+  return Array.from(tribeMap.values()).map(finalize);
+}
+
+function applySearch(roots, query) {
+  if (!query) {
+    const reset = (node) => {
+      node.isMatch = false;
+      node.visible = true;
+      node.children.forEach(reset);
+    };
+    roots.forEach(reset);
+    return roots;
+  }
+  const lower = query.toLowerCase();
+
+  const filterNode = (node) => {
+    const selfMatch = node.searchTerms.some((term) => term.includes(lower));
+    const filteredChildren = node.children
+      .map(filterNode)
+      .filter((child) => child.visible);
+    node.children = filteredChildren;
+    node.isMatch = selfMatch;
+    node.visible = selfMatch || filteredChildren.length > 0;
+    return node;
+  };
+
+  return roots
+    .map(filterNode)
+    .filter((node) => node.visible);
+}
+
+function computeLayout(roots) {
+  const positions = [];
+  const links = [];
+  let maxDepth = 0;
+
+  const subtreeWidth = (node) => {
+    if (!node.children || node.children.length === 0) {
+      node._width = 1;
+      return 1;
+    }
+    let width = 0;
+    node.children.forEach((child) => {
+      width += subtreeWidth(child);
+    });
+    node._width = Math.max(width, 1);
+    return node._width;
+  };
+
+  const place = (node, depth, offset) => {
+    const width = node._width || 1;
+    const xCenter = offset + (width - 1) / 2;
+    positions.push({ node, depth, x: xCenter });
+    maxDepth = Math.max(maxDepth, depth);
+    let childOffset = offset;
+    node.children.forEach((child) => {
+      place(child, depth + 1, childOffset);
+      links.push({ from: node, to: child });
+      childOffset += child._width || 1;
+    });
+  };
+
+  let offset = 0;
+  roots.forEach((root) => {
+    subtreeWidth(root);
+    place(root, 0, offset);
+    offset += root._width || 1;
+  });
+
+  const widthUnits = offset;
+  const widthPx = Math.max(widthUnits * HORIZONTAL_GAP, elements.chartContainer.clientWidth / state.scale);
+  const heightPx = Math.max((maxDepth + 1) * VERTICAL_GAP, elements.chartContainer.clientHeight / state.scale);
+
+  const positionMap = new Map();
+  positions.forEach((entry) => {
+    positionMap.set(entry.node, entry);
+  });
+
+  return {
+    nodes: positions,
+    nodePositions: positionMap,
+    links,
+    widthPx,
+    heightPx,
+  };
+}
+
+function renderNodes(layout) {
+  const { nodes, widthPx, heightPx } = layout;
+  const scaledWidth = Math.max(widthPx * state.scale, elements.chartContainer.clientWidth);
+  const scaledHeight = Math.max(heightPx * state.scale, elements.chartContainer.clientHeight);
+  elements.chartContent.style.width = `${scaledWidth}px`;
+  elements.chartContent.style.height = `${scaledHeight}px`;
+  elements.chartZoom.style.width = `${widthPx}px`;
+  elements.chartZoom.style.height = `${heightPx}px`;
+  elements.chartZoom.style.transform = `scale(${state.scale})`;
+  elements.chartNodes.innerHTML = "";
+
+  nodes.forEach(({ node, depth, x }) => {
+    const card = document.createElement("article");
+    card.classList.add("node-card");
+    if (node.type !== "employee") {
+      card.classList.add("group");
+    }
+    if (node.isMatch) {
+      card.classList.add("match");
+    }
+
+    const top = depth * VERTICAL_GAP + VERTICAL_GAP / 2 - NODE_HEIGHT / 2;
+    const left = x * HORIZONTAL_GAP + HORIZONTAL_GAP / 2 - NODE_WIDTH / 2;
+
+    card.style.transform = `translate(${left}px, ${top}px)`;
+
+    card.innerHTML = buildCardContent(node);
+
+    if (node.hasChildren) {
+      const toggle = document.createElement("button");
+      toggle.classList.add("collapse-toggle");
+      toggle.type = "button";
+      toggle.textContent = node.collapsed ? "+" : "−";
+      toggle.addEventListener("click", (event) => {
+        event.stopPropagation();
+        toggleNode(node);
+      });
+      card.appendChild(toggle);
+    }
+
+    card.addEventListener("click", () => {
+      if (node.hasChildren) {
+        toggleNode(node);
+      }
+    });
+
+    elements.chartNodes.appendChild(card);
+  });
+}
+
+function renderLinks(layout) {
+  const { links, nodePositions } = layout;
+  const svgNS = "http://www.w3.org/2000/svg";
+  elements.chartLinks.setAttribute("width", "100%");
+  elements.chartLinks.setAttribute("height", "100%");
+  elements.chartLinks.innerHTML = "";
+
+  links.forEach(({ from, to }) => {
+    const parentPos = nodePositions.get(from);
+    const childPos = nodePositions.get(to);
+    if (!parentPos || !childPos) return;
+
+    const startX = parentPos.x * HORIZONTAL_GAP + HORIZONTAL_GAP / 2;
+    const startY = parentPos.depth * VERTICAL_GAP + VERTICAL_GAP / 2 + NODE_HEIGHT / 2;
+    const endX = childPos.x * HORIZONTAL_GAP + HORIZONTAL_GAP / 2;
+    const endY = childPos.depth * VERTICAL_GAP + VERTICAL_GAP / 2 - NODE_HEIGHT / 2;
+    const controlY = (startY + endY) / 2;
+
+    const path = document.createElementNS(svgNS, "path");
+    path.setAttribute(
+      "d",
+      `M${startX},${startY} C ${startX},${controlY} ${endX},${controlY} ${endX},${endY}`
+    );
+    path.setAttribute("fill", "none");
+    path.setAttribute("stroke", "rgba(148, 163, 184, 0.5)");
+    path.setAttribute("stroke-width", "2");
+    elements.chartLinks.appendChild(path);
+  });
+}
+
+function toggleNode(node) {
+  if (state.search) return; // disable toggling while filtering
+  if (state.collapsed.has(node.id)) {
+    state.collapsed.delete(node.id);
+  } else {
+    state.collapsed.add(node.id);
+  }
+  render();
+}
+
+function drawMinimap(layout) {
+  const ctx = elements.minimap.getContext("2d");
+  ctx.clearRect(0, 0, elements.minimap.width, elements.minimap.height);
+
+  if (!layout || !layout.nodes.length) {
+    ctx.fillStyle = "rgba(148, 163, 184, 0.3)";
+    ctx.font = "12px Inter, sans-serif";
+    ctx.textAlign = "center";
+    ctx.fillText("No data", elements.minimap.width / 2, elements.minimap.height / 2);
+    return;
+  }
+
+  const { widthPx, heightPx } = layout;
+  const { scale, offsetX, offsetY } = getMinimapScaling(widthPx, heightPx);
+
+  ctx.save();
+  ctx.translate(offsetX, offsetY);
+  ctx.scale(scale, scale);
+
+  ctx.strokeStyle = "rgba(148, 163, 184, 0.35)";
+  ctx.lineWidth = 1 / scale;
+  layout.links.forEach(({ from, to }) => {
+    const parentPos = layout.nodePositions.get(from);
+    const childPos = layout.nodePositions.get(to);
+    if (!parentPos || !childPos) return;
+    const startX = parentPos.x * HORIZONTAL_GAP + HORIZONTAL_GAP / 2;
+    const startY = parentPos.depth * VERTICAL_GAP + VERTICAL_GAP / 2;
+    const endX = childPos.x * HORIZONTAL_GAP + HORIZONTAL_GAP / 2;
+    const endY = childPos.depth * VERTICAL_GAP + VERTICAL_GAP / 2;
+    ctx.beginPath();
+    ctx.moveTo(startX, startY);
+    ctx.lineTo(endX, endY);
+    ctx.stroke();
+  });
+
+  layout.nodes.forEach(({ node, depth, x }) => {
+    const cx = x * HORIZONTAL_GAP + HORIZONTAL_GAP / 2;
+    const cy = depth * VERTICAL_GAP + VERTICAL_GAP / 2;
+    ctx.fillStyle = node.type === "employee" ? "#2563eb" : "#0ea5e9";
+    ctx.fillRect(cx - 6, cy - 6, 12, 12);
+  });
+
+  ctx.restore();
+
+  // viewport rectangle
+  const visibleWidth = elements.chartContainer.clientWidth / state.scale;
+  const visibleHeight = elements.chartContainer.clientHeight / state.scale;
+  const scrollLeft = elements.chartContainer.scrollLeft / state.scale;
+  const scrollTop = elements.chartContainer.scrollTop / state.scale;
+
+  ctx.save();
+  ctx.translate(offsetX, offsetY);
+  ctx.scale(scale, scale);
+  ctx.strokeStyle = "rgba(37, 99, 235, 0.8)";
+  ctx.lineWidth = 1 / scale;
+  ctx.strokeRect(scrollLeft, scrollTop, visibleWidth, visibleHeight);
+  ctx.restore();
+}
+
+function getMinimapScaling(widthPx, heightPx) {
+  const padding = 16;
+  const maxWidth = elements.minimap.width - padding * 2;
+  const maxHeight = elements.minimap.height - padding * 2;
+  const scale = Math.min(maxWidth / widthPx, maxHeight / heightPx, 1);
+  const offsetX = (elements.minimap.width - widthPx * scale) / 2;
+  const offsetY = (elements.minimap.height - heightPx * scale) / 2;
+  return { scale, offsetX, offsetY };
+}
+
+function mapRows(rawRows) {
+  return rawRows
+    .map((row) => normalizeRow(row))
+    .filter((row) => row.name);
+}
+
+function normalizeRow(row) {
+  const normalized = {};
+  Object.entries(row).forEach(([key, value]) => {
+    normalized[normalizeColumnName(key)] = typeof value === "string" ? value.trim() : value;
+  });
+
+  const result = {
+    name: pickAlias(normalized, "name"),
+    tribe: pickAlias(normalized, "tribe"),
+    squad: pickAlias(normalized, "squad"),
+    expertise: pickAlias(normalized, "expertise"),
+    level: pickAlias(normalized, "level"),
+    manager: pickAlias(normalized, "manager"),
+  };
+
+  return Object.fromEntries(
+    Object.entries(result).map(([key, value]) => [key, typeof value === "string" ? value.trim() : value])
+  );
+}
+
+function pickAlias(row, field) {
+  const aliases = COLUMN_ALIASES[field] || [];
+  for (const alias of aliases) {
+    if (row.hasOwnProperty(alias)) {
+      return row[alias];
+    }
+  }
+  return row[field] ?? "";
+}
+
+function normalizeColumnName(name) {
+  return name
+    .toLowerCase()
+    .replace(/[_-]+/g, " ")
+    .replace(/[^a-z0-9 ]+/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function buildSearchTerms(row, fallback) {
+  return [
+    fallback?.toLowerCase?.() || "",
+    row.name?.toLowerCase?.() || "",
+    row.tribe?.toLowerCase?.() || "",
+    row.squad?.toLowerCase?.() || "",
+    row.expertise?.toLowerCase?.() || "",
+    row.level?.toLowerCase?.() || "",
+    row.manager?.toLowerCase?.() || "",
+  ].filter(Boolean);
+}
+
+function buildCardContent(node) {
+  if (node.type === "tribe") {
+    return `
+      <h3 class="title">${escapeHtml(node.label)}</h3>
+      <p class="meta">Tribe · ${node.originalChildren.length} squads</p>
+    `;
+  }
+  if (node.type === "squad") {
+    return `
+      <div class="badge">Squad</div>
+      <h3 class="title">${escapeHtml(node.label)}</h3>
+      <p class="meta">${node.originalChildren.length} people · ${escapeHtml(node.data.tribe)}</p>
+    `;
+  }
+  if (node.type === "placeholder") {
+    return `
+      <div class="badge">Manager</div>
+      <h3 class="title">${escapeHtml(node.label)}</h3>
+      <p class="meta">${node.originalChildren.length} direct reports</p>
+    `;
+  }
+
+  const { expertise, tribe, squad, level, manager } = node.data;
+  const teamLine = [tribe, squad].filter(Boolean).map(escapeHtml).join(" · ");
+  return `
+    <div class="badge">${escapeHtml(level || "Employee")}</div>
+    <h3 class="title">${escapeHtml(node.label)}</h3>
+    <p class="meta">
+      <span>${escapeHtml(expertise || "")}</span>
+      ${teamLine ? `<span>${teamLine}</span>` : ""}
+      <span>Manager: ${escapeHtml(manager || "–")}</span>
+    </p>
+  `;
+}
+
+function toggleLoader(active) {
+  elements.chartContainer.classList.toggle("loading", active);
+}
+
+function updateStatus(message, isError = false) {
+  elements.statusMessage.textContent = message;
+  elements.statusBar.style.color = isError ? "#ef4444" : "var(--color-subtle)";
+}
+
+function escapeHtml(value) {
+  if (value == null) return "";
+  return value
+    .toString()
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+function extractGoogleSheetId(url) {
+  const patterns = [
+    /spreadsheets\/d\/([a-zA-Z0-9-_]+)/,
+    /spreadsheets\?id=([a-zA-Z0-9-_]+)/,
+  ];
+  for (const pattern of patterns) {
+    const match = url.match(pattern);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+function parseCsv(text) {
+  const lines = text.split(/\r?\n/).filter(Boolean);
+  if (!lines.length) return [];
+  const headers = splitCsvLine(lines[0]);
+  return lines.slice(1).map((line) => {
+    const cells = splitCsvLine(line);
+    const row = {};
+    headers.forEach((header, index) => {
+      row[header] = cells[index] ?? "";
+    });
+    return row;
+  });
+}
+
+function splitCsvLine(line) {
+  const result = [];
+  let current = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === "," && !inQuotes) {
+      result.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  result.push(current);
+  return result.map((value) => value.trim());
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function updateThemeButton(theme) {
+  elements.themeToggle.querySelector(".icon").textContent = theme === "dark" ? "☀️" : "🌙";
+}
+
+// initial render with sample data for a quick start
+if (!state.rows.length) {
+  state.rows = [...SAMPLE_DATA];
+  render();
+  updateStatus("Showing sample data. Upload a file to replace.");
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Organizational Chart Explorer</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/xlsx@0.19.3/dist/xlsx.full.min.js" defer></script>
+    <script src="app.js" type="module" defer></script>
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="top-bar">
+        <div class="branding">
+          <h1>Org Navigator</h1>
+          <p class="subtitle">Visualize teams straight from your spreadsheet</p>
+        </div>
+        <div class="top-bar-controls">
+          <label class="switch" title="Toggle between Tribe view and Manager view">
+            <input type="checkbox" id="view-toggle" />
+            <span class="slider"></span>
+            <span class="switch-labels">
+              <span>Tribe</span>
+              <span>Manager</span>
+            </span>
+          </label>
+          <button id="theme-toggle" class="icon-button" title="Toggle dark mode">
+            <span class="icon" aria-hidden="true">🌙</span>
+            <span class="sr-only">Toggle dark mode</span>
+          </button>
+        </div>
+      </header>
+
+      <section class="controls">
+        <div class="input-group">
+          <label class="file-upload" for="file-input">
+            <span class="icon" aria-hidden="true">📄</span>
+            <span>Upload .xlsx</span>
+          </label>
+          <input type="file" accept=".xlsx,.xlsm" id="file-input" />
+        </div>
+        <div class="input-group google-link">
+          <input
+            type="url"
+            id="sheet-url"
+            placeholder="Paste Google Sheets share link"
+            autocomplete="off"
+          />
+          <button id="load-sheet" class="primary-button">Load sheet</button>
+        </div>
+        <div class="input-group search-group">
+          <span class="icon" aria-hidden="true">🔍</span>
+          <input
+            type="search"
+            id="search-input"
+            placeholder="Search names, tribes, squads, expertise, job levels or managers"
+            autocomplete="off"
+          />
+          <button id="clear-search" class="icon-button" title="Clear search">
+            <span class="icon" aria-hidden="true">✕</span>
+            <span class="sr-only">Clear search</span>
+          </button>
+        </div>
+        <button id="load-sample" class="ghost-button">Use sample data</button>
+      </section>
+
+      <main class="workspace">
+        <aside class="minimap-panel">
+          <div class="panel-header">
+            <h2>Mini map</h2>
+            <p class="hint">Click to navigate</p>
+          </div>
+          <canvas id="minimap" width="200" height="200" role="img" aria-label="Organizational chart overview"></canvas>
+        </aside>
+
+        <section class="chart-area">
+          <div id="chart-container">
+            <div id="chart-content">
+              <div id="chart-zoom">
+                <svg id="chart-links"></svg>
+                <div id="chart-nodes"></div>
+              </div>
+            </div>
+          </div>
+          <div class="empty-state" id="empty-state">
+            <h2>Upload a spreadsheet to get started</h2>
+            <p>
+              Use the sample data or drop in your own file with columns for employee name,
+              tribe, squad, expertise, job level and manager name.
+            </p>
+          </div>
+          <div class="fab" id="fab">
+            <button class="fab-button" data-action="zoom-in" title="Zoom in">＋</button>
+            <button class="fab-button" data-action="zoom-out" title="Zoom out">－</button>
+            <button class="fab-button" data-action="zoom-fit" title="Zoom to fit">⤢</button>
+            <button class="fab-button" data-action="expand" title="Expand all">⤦</button>
+            <button class="fab-button" data-action="collapse" title="Collapse all">⤣</button>
+          </div>
+        </section>
+      </main>
+
+      <footer class="status-bar" id="status-bar">
+        <span id="status-message">No data loaded</span>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,544 @@
+:root {
+  --color-bg: #f5f7fb;
+  --color-surface: #ffffff;
+  --color-text: #1f2933;
+  --color-subtle: #64748b;
+  --color-accent: #2563eb;
+  --color-border: #dbe1f1;
+  --color-card-shadow: rgba(15, 23, 42, 0.08);
+  --color-card-shadow-strong: rgba(15, 23, 42, 0.16);
+  --color-success: #0ea5e9;
+}
+
+[data-theme="dark"] {
+  --color-bg: #0f172a;
+  --color-surface: #111b2f;
+  --color-text: #e2e8f0;
+  --color-subtle: #94a3b8;
+  --color-accent: #60a5fa;
+  --color-border: #1e293b;
+  --color-card-shadow: rgba(15, 23, 42, 0.35);
+  --color-card-shadow-strong: rgba(15, 23, 42, 0.65);
+  --color-success: #38bdf8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  background: var(--color-bg);
+  color: var(--color-text);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+}
+
+.app-shell {
+  width: min(1200px, 100%);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: var(--color-bg);
+}
+
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem clamp(1.2rem, 2vw, 2rem) 1rem;
+  gap: 1.5rem;
+}
+
+.branding h1 {
+  margin: 0;
+  font-size: clamp(1.4rem, 3vw, 1.9rem);
+  font-weight: 700;
+}
+
+.branding .subtitle {
+  margin: 0.35rem 0 0;
+  color: var(--color-subtle);
+  font-size: 0.95rem;
+}
+
+.top-bar-controls {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.switch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.switch input {
+  display: none;
+}
+
+.slider {
+  position: relative;
+  width: 3rem;
+  height: 1.6rem;
+  background: var(--color-border);
+  border-radius: 999px;
+  transition: background 0.3s ease;
+}
+
+.slider::after {
+  content: "";
+  position: absolute;
+  top: 0.2rem;
+  left: 0.2rem;
+  width: 1.2rem;
+  height: 1.2rem;
+  background: var(--color-surface);
+  border-radius: 50%;
+  box-shadow: 0 2px 4px var(--color-card-shadow);
+  transition: transform 0.3s ease;
+}
+
+.switch input:checked + .slider {
+  background: var(--color-accent);
+}
+
+.switch input:checked + .slider::after {
+  transform: translateX(1.4rem);
+}
+
+.switch-labels {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.65rem;
+  color: var(--color-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+}
+
+.switch-labels span:last-child {
+  color: var(--color-text);
+}
+
+.icon-button,
+.ghost-button,
+.primary-button,
+.file-upload {
+  border: none;
+  background: none;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+
+.icon-button {
+  width: 2.4rem;
+  height: 2.4rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: 0 1px 2px var(--color-card-shadow);
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.icon-button:hover,
+.icon-button:focus-visible {
+  background: var(--color-border);
+}
+
+.icon-button:active {
+  transform: scale(0.95);
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  padding: 0 1.5rem 1.5rem;
+}
+
+.input-group {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 0.9rem;
+  padding: 0.6rem 0.8rem;
+  box-shadow: 0 10px 20px -15px var(--color-card-shadow);
+}
+
+.input-group input[type="file"] {
+  display: none;
+}
+
+.file-upload {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.google-link {
+  padding-right: 0.4rem;
+}
+
+.google-link input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+  outline: none;
+}
+
+.primary-button {
+  padding: 0.55rem 1rem;
+  border-radius: 0.75rem;
+  background: var(--color-accent);
+  color: #fff;
+  font-weight: 600;
+  box-shadow: 0 12px 30px -15px var(--color-card-shadow-strong);
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.primary-button:hover,
+.primary-button:focus-visible {
+  background: color-mix(in srgb, var(--color-accent) 85%, #ffffff 15%);
+}
+
+.primary-button:active {
+  transform: translateY(1px);
+}
+
+.search-group {
+  flex: 1;
+  min-width: 240px;
+}
+
+.search-group input[type="search"] {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font: inherit;
+  outline: none;
+}
+
+.ghost-button {
+  justify-self: start;
+  padding: 0.55rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px dashed var(--color-border);
+  color: var(--color-subtle);
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.ghost-button:hover,
+.ghost-button:focus-visible {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.workspace {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  gap: 1.5rem;
+  padding: 0 1.5rem 1.5rem;
+  position: relative;
+}
+
+@media (max-width: 960px) {
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .minimap-panel {
+    order: 2;
+    position: sticky;
+    bottom: 0;
+  }
+}
+
+.minimap-panel {
+  background: var(--color-surface);
+  border-radius: 1.2rem;
+  padding: 1.2rem;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 20px 35px -25px var(--color-card-shadow-strong);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  height: fit-content;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.panel-header .hint {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--color-subtle);
+}
+
+#minimap {
+  width: 100%;
+  height: 200px;
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-border);
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.08), transparent);
+  cursor: crosshair;
+}
+
+.chart-area {
+  position: relative;
+  background: var(--color-surface);
+  border-radius: 1.4rem;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 25px 50px -25px var(--color-card-shadow-strong);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+#chart-container {
+  position: relative;
+  flex: 1;
+  overflow: auto;
+  padding: 1.5rem;
+}
+
+#chart-content {
+  position: relative;
+  min-width: 100%;
+  min-height: 100%;
+}
+
+#chart-zoom {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform-origin: top left;
+  width: 100%;
+  height: 100%;
+}
+
+#chart-links {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  pointer-events: none;
+}
+
+#chart-nodes {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.node-card {
+  position: absolute;
+  width: 220px;
+  min-height: 120px;
+  background: var(--color-surface);
+  border-radius: 1rem;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 16px 30px -20px var(--color-card-shadow-strong);
+  padding: 0.9rem 1rem;
+  transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+
+.node-card:hover,
+.node-card:focus-within {
+  border-color: var(--color-accent);
+  box-shadow: 0 25px 35px -25px var(--color-card-shadow-strong);
+  transform: translateY(-2px);
+}
+
+.node-card.group {
+  background: color-mix(in srgb, var(--color-accent) 12%, var(--color-surface) 88%);
+}
+
+.node-card .title {
+  font-weight: 600;
+  font-size: 1rem;
+  margin: 0;
+}
+
+.node-card .meta {
+  margin: 0.4rem 0 0;
+  color: var(--color-subtle);
+  font-size: 0.82rem;
+  display: grid;
+  gap: 0.2rem;
+}
+
+.node-card .badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-accent) 16%, transparent 84%);
+  color: var(--color-accent);
+  font-weight: 600;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.node-card .collapse-toggle {
+  position: absolute;
+  top: 0.4rem;
+  right: 0.4rem;
+  border: none;
+  background: rgba(15, 23, 42, 0.05);
+  color: inherit;
+  border-radius: 0.6rem;
+  width: 1.5rem;
+  height: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+[data-theme="dark"] .node-card .collapse-toggle {
+  background: rgba(226, 232, 240, 0.08);
+}
+
+.node-card .collapse-toggle:hover {
+  background: rgba(37, 99, 235, 0.15);
+}
+
+.node-card.match {
+  border-color: var(--color-success);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-success) 30%, transparent 70%);
+}
+
+.node-card.hidden {
+  display: none;
+}
+
+.empty-state {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  text-align: center;
+  padding: 2rem;
+  color: var(--color-subtle);
+}
+
+.empty-state h2 {
+  color: var(--color-text);
+}
+
+.fab {
+  position: absolute;
+  right: 1rem;
+  bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.fab-button {
+  width: 2.6rem;
+  height: 2.6rem;
+  border-radius: 50%;
+  border: none;
+  background: var(--color-accent);
+  color: #fff;
+  font-weight: 700;
+  font-size: 1.1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 18px 30px -20px var(--color-card-shadow-strong);
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.fab-button:hover,
+.fab-button:focus-visible {
+  transform: translateY(-1px);
+}
+
+.status-bar {
+  border-top: 1px solid var(--color-border);
+  padding: 0.75rem 1.5rem;
+  color: var(--color-subtle);
+  font-size: 0.85rem;
+  background: var(--color-surface);
+}
+
+.icon {
+  font-size: 1rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 768px) {
+  .top-bar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .top-bar-controls {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .controls {
+    grid-template-columns: 1fr;
+  }
+
+  .workspace {
+    padding-bottom: 5rem;
+  }
+
+  .fab {
+    right: 0.6rem;
+    bottom: 0.6rem;
+  }
+}
+


### PR DESCRIPTION
## Summary
- create a single-page app that ingests Excel or Google Sheets data to render a searchable org chart
- implement tribe and manager tree layouts with zoom, collapse/expand, and minimap navigation controls
- style the interface with responsive light/dark themes and document usage in the README

## Testing
- Manual: Loaded index.html in a browser

------
https://chatgpt.com/codex/tasks/task_e_68e646d61f50832da4d6a4cb3ceadb48