### PR TITLE
Redesign org chart interface to match provided layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# Organizational-chart
+# Organizational Chart Explorer
+
+A lightweight, client-side web app for visualizing an organization's structure from an Excel workbook or Google Sheets link. Switch between tribe-based and manager-based views, search across employee attributes, and navigate large hierarchies with a built-in mini map and zoom controls.
+
+## Getting started
+
+1. Open `index.html` in your browser. No build tools are required.
+2. Upload an `.xlsx` file or paste a Google Sheets share link with columns for:
+   - Employee name
+   - Tribe
+   - Squad
+   - Expertise
+   - Job level
+   - Manager name
+3. Use the view toggle to switch between tribe and manager views.
+4. Use the search bar and scope chips to filter by specific employee attributes.
+5. Explore the chart with the floating controls (expand/collapse, zoom, and zoom-to-fit) or the minimap.
+
+A curated sample dataset is loaded automatically so you can try the interface immediately. Click **Use sample data** to restore the sample if needed.
+
+## Development notes
+
+- All processing happens in the browser using [SheetJS](https://sheetjs.com/) via CDN to parse Excel files.
+- Google Sheets links are converted to CSV via the public export endpoint. Ensure the sheet is shared accordingly.
+- The layout is computed on the fly with a simple tree layout algorithm; no external frameworks are required.
+
+Feel free to customize the styling in `styles.css` or extend the rendering logic in `app.js` to suit your organization.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,1067 @@
+const NODE_WIDTH = 220;
+const NODE_HEIGHT = 120;
+const HORIZONTAL_GAP = 260;
+const VERTICAL_GAP = 200;
+const MIN_SCALE = 0.4;
+const MAX_SCALE = 2.4;
+const SCALE_STEP = 0.15;
+
+const COLUMN_ALIASES = {
+  name: ["employee name", "name", "full name"],
+  tribe: ["tribe", "chapter", "department", "group"],
+  squad: ["squad", "team", "unit"],
+  expertise: ["expertise", "role", "function", "speciality", "specialty"],
+  level: ["job level", "level", "grade"],
+  manager: ["manager name", "manager", "reporting to", "reports to"],
+};
+
+const SAMPLE_DATA = [
+  {
+    name: "Aria Chen",
+    tribe: "Product",
+    squad: "Discovery",
+    expertise: "Product Manager",
+    level: "Senior",
+    manager: "Daniel Rivera",
+  },
+  {
+    name: "Jonas Patel",
+    tribe: "Product",
+    squad: "Discovery",
+    expertise: "UX Researcher",
+    level: "Mid",
+    manager: "Aria Chen",
+  },
+  {
+    name: "Lila Mensah",
+    tribe: "Product",
+    squad: "Discovery",
+    expertise: "Product Designer",
+    level: "Mid",
+    manager: "Aria Chen",
+  },
+  {
+    name: "Mateo García",
+    tribe: "Product",
+    squad: "Growth",
+    expertise: "Product Manager",
+    level: "Lead",
+    manager: "Daniel Rivera",
+  },
+  {
+    name: "Sofia Novak",
+    tribe: "Engineering",
+    squad: "Growth",
+    expertise: "Frontend Engineer",
+    level: "Mid",
+    manager: "Mateo García",
+  },
+  {
+    name: "Emily Stone",
+    tribe: "Engineering",
+    squad: "Growth",
+    expertise: "Backend Engineer",
+    level: "Senior",
+    manager: "Mateo García",
+  },
+  {
+    name: "Kai Nakamura",
+    tribe: "Engineering",
+    squad: "Platform",
+    expertise: "DevOps Engineer",
+    level: "Senior",
+    manager: "Priya Desai",
+  },
+  {
+    name: "Priya Desai",
+    tribe: "Engineering",
+    squad: "Platform",
+    expertise: "Engineering Manager",
+    level: "Lead",
+    manager: "Daniel Rivera",
+  },
+  {
+    name: "Daniel Rivera",
+    tribe: "Executive",
+    squad: "Leadership",
+    expertise: "VP of Product & Engineering",
+    level: "Executive",
+    manager: "",
+  },
+  {
+    name: "Noah Jensen",
+    tribe: "People",
+    squad: "Operations",
+    expertise: "People Partner",
+    level: "Senior",
+    manager: "Daniel Rivera",
+  },
+  {
+    name: "Amelia Fox",
+    tribe: "People",
+    squad: "Operations",
+    expertise: "Recruiter",
+    level: "Mid",
+    manager: "Noah Jensen",
+  },
+];
+
+const SEARCH_PLACEHOLDERS = {
+  all: "Search employees, tribes, squads, expertise, job levels or managers",
+  name: "Search by employee name",
+  tribe: "Search by tribe",
+  squad: "Search by squad",
+  expertise: "Search by expertise",
+  level: "Search by job level",
+  manager: "Search by manager",
+};
+
+const state = {
+  rows: [],
+  view: "manager",
+  collapsed: new Set(),
+  search: "",
+  searchField: "all",
+  scale: 1,
+  layout: null,
+};
+
+const elements = {
+  themeToggle: document.getElementById("theme-toggle"),
+  viewToggleButtons: Array.from(document.querySelectorAll("[data-view-mode]")),
+  fileInput: document.getElementById("file-input"),
+  sheetUrl: document.getElementById("sheet-url"),
+  loadSheet: document.getElementById("load-sheet"),
+  loadSample: document.getElementById("load-sample"),
+  searchInput: document.getElementById("search-input"),
+  clearSearch: document.getElementById("clear-search"),
+  searchFilterChips: Array.from(document.querySelectorAll("[data-search-field]")),
+  chartContainer: document.getElementById("chart-container"),
+  chartContent: document.getElementById("chart-content"),
+  chartZoom: document.getElementById("chart-zoom"),
+  chartLinks: document.getElementById("chart-links"),
+  chartNodes: document.getElementById("chart-nodes"),
+  minimap: document.getElementById("minimap"),
+  emptyState: document.getElementById("empty-state"),
+  statusBar: document.getElementById("status-bar"),
+  statusMessage: document.getElementById("status-message"),
+  fab: document.getElementById("fab"),
+};
+
+const themePreference = localStorage.getItem("org-nav-theme");
+if (themePreference) {
+  document.documentElement.setAttribute("data-theme", themePreference);
+  updateThemeButton(themePreference);
+}
+
+elements.themeToggle.addEventListener("click", () => {
+  const current = document.documentElement.getAttribute("data-theme") || "light";
+  const next = current === "light" ? "dark" : "light";
+  document.documentElement.setAttribute("data-theme", next);
+  localStorage.setItem("org-nav-theme", next);
+  updateThemeButton(next);
+});
+
+elements.viewToggleButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    const view = button.dataset.viewMode;
+    if (!view || view === state.view) return;
+    state.view = view;
+    state.collapsed.clear();
+    updateViewModeUI();
+    render();
+  });
+});
+
+elements.searchFilterChips.forEach((chip) => {
+  chip.addEventListener("click", () => {
+    const field = chip.dataset.searchField;
+    if (!field || field === state.searchField) return;
+    state.searchField = field;
+    updateSearchScopeUI();
+    updateSearchPlaceholder();
+    if (state.search) {
+      render();
+    }
+  });
+});
+
+updateViewModeUI();
+updateSearchScopeUI();
+updateSearchPlaceholder();
+updateClearButton();
+updateThemeButton(document.documentElement.getAttribute("data-theme") || "light");
+
+elements.fileInput.addEventListener("change", async (event) => {
+  const file = event.target.files?.[0];
+  if (!file) return;
+  try {
+    updateStatus(`Loading ${file.name}…`);
+    const buffer = await file.arrayBuffer();
+    const workbook = XLSX.read(buffer, { type: "array" });
+    const sheetName = workbook.SheetNames[0];
+    if (!sheetName) throw new Error("No sheets detected in the workbook");
+    const worksheet = workbook.Sheets[sheetName];
+    const rawRows = XLSX.utils.sheet_to_json(worksheet, { defval: "" });
+    state.rows = mapRows(rawRows);
+    state.collapsed.clear();
+    state.search = "";
+    elements.searchInput.value = "";
+    updateClearButton();
+    render();
+    updateStatus(`Loaded ${state.rows.length} rows from ${sheetName}`);
+  } catch (error) {
+    console.error(error);
+    updateStatus(`Failed to load spreadsheet: ${error.message}`, true);
+  } finally {
+    event.target.value = "";
+  }
+});
+
+elements.loadSheet.addEventListener("click", async () => {
+  const url = elements.sheetUrl.value.trim();
+  if (!url) {
+    updateStatus("Please paste a Google Sheets URL", true);
+    return;
+  }
+  const sheetId = extractGoogleSheetId(url);
+  if (!sheetId) {
+    updateStatus("Could not parse the Google Sheets link", true);
+    return;
+  }
+  try {
+    updateStatus("Fetching Google Sheet…");
+    const response = await fetch(
+      `https://docs.google.com/spreadsheets/d/${sheetId}/gviz/tq?tqx=out:csv`
+    );
+    if (!response.ok) {
+      throw new Error(`Google Sheets request failed (${response.status})`);
+    }
+    const csvText = await response.text();
+    const rows = parseCsv(csvText);
+    state.rows = mapRows(rows);
+    state.collapsed.clear();
+    state.search = "";
+    elements.searchInput.value = "";
+    updateClearButton();
+    render();
+    updateStatus(`Loaded ${state.rows.length} rows from Google Sheets`);
+  } catch (error) {
+    console.error(error);
+    updateStatus(`Failed to fetch Google Sheets data: ${error.message}`, true);
+  }
+});
+
+elements.loadSample.addEventListener("click", () => {
+  state.rows = [...SAMPLE_DATA];
+  state.collapsed.clear();
+  state.search = "";
+  elements.searchInput.value = "";
+  updateClearButton();
+  render();
+  updateStatus("Loaded sample organization data");
+});
+
+elements.searchInput.addEventListener("input", (event) => {
+  state.search = event.target.value.trim();
+  updateClearButton();
+  render();
+});
+
+elements.clearSearch.addEventListener("click", () => {
+  if (!state.search) return;
+  state.search = "";
+  elements.searchInput.value = "";
+  updateClearButton();
+  render();
+});
+
+elements.fab.addEventListener("click", (event) => {
+  const button = event.target.closest(".fab-button");
+  if (!button) return;
+  const action = button.dataset.action;
+  switch (action) {
+    case "zoom-in":
+      setScale(state.scale + SCALE_STEP);
+      break;
+    case "zoom-out":
+      setScale(state.scale - SCALE_STEP);
+      break;
+    case "zoom-fit":
+      zoomToFit();
+      break;
+    case "expand":
+      state.collapsed.clear();
+      render();
+      break;
+    case "collapse":
+      collapseAll();
+      break;
+    default:
+      break;
+  }
+});
+
+elements.chartContainer.addEventListener("scroll", () => {
+  drawMinimap(state.layout);
+});
+
+window.addEventListener("resize", () => {
+  drawMinimap(state.layout);
+});
+
+elements.minimap.addEventListener("click", (event) => {
+  if (!state.layout) return;
+  const { widthPx, heightPx } = state.layout;
+  if (!widthPx || !heightPx) return;
+
+  const rect = elements.minimap.getBoundingClientRect();
+  const x = event.clientX - rect.left;
+  const y = event.clientY - rect.top;
+
+  const { scale, offsetX, offsetY } = getMinimapScaling(widthPx, heightPx);
+  const chartX = (x - offsetX) / scale;
+  const chartY = (y - offsetY) / scale;
+
+  const targetX = chartX * state.scale - elements.chartContainer.clientWidth / 2;
+  const targetY = chartY * state.scale - elements.chartContainer.clientHeight / 2;
+  elements.chartContainer.scrollTo({
+    left: clamp(targetX, 0, elements.chartContainer.scrollWidth),
+    top: clamp(targetY, 0, elements.chartContainer.scrollHeight),
+    behavior: "smooth",
+  });
+});
+
+function setScale(next) {
+  const clamped = clamp(next, MIN_SCALE, MAX_SCALE);
+  if (Math.abs(clamped - state.scale) < 0.001) return;
+  state.scale = clamped;
+  render();
+}
+
+function zoomToFit() {
+  if (!state.layout) return;
+  const containerWidth = elements.chartContainer.clientWidth;
+  const containerHeight = elements.chartContainer.clientHeight;
+  if (containerWidth === 0 || containerHeight === 0) return;
+
+  const { widthPx, heightPx } = state.layout;
+  if (!widthPx || !heightPx) return;
+
+  const scaleX = containerWidth / widthPx;
+  const scaleY = containerHeight / heightPx;
+  const nextScale = clamp(Math.min(scaleX, scaleY) * 0.92, MIN_SCALE, MAX_SCALE);
+  state.scale = nextScale;
+  render();
+}
+
+function collapseAll() {
+  const tree = buildTree();
+  const ids = [];
+  const collect = (node) => {
+    if (node.children?.length) {
+      ids.push(node.id);
+      node.children.forEach(collect);
+    }
+  };
+  tree.forEach(collect);
+  state.collapsed = new Set(ids);
+  render();
+}
+
+function render() {
+  if (!state.rows.length) {
+    elements.chartNodes.innerHTML = "";
+    elements.chartLinks.innerHTML = "";
+    state.layout = null;
+    elements.emptyState.style.display = "flex";
+    drawMinimap(null);
+    return;
+  }
+
+  const tree = buildTree();
+  const filteredTree = applySearch(tree, state.search);
+  const layout = computeLayout(filteredTree);
+  state.layout = layout;
+
+  renderLinks(layout);
+  renderNodes(layout);
+  elements.emptyState.style.display = "none";
+  drawMinimap(layout);
+}
+
+function buildTree() {
+  return state.view === "manager"
+    ? buildManagerTree(state.rows)
+    : buildTribeTree(state.rows);
+}
+
+function buildManagerTree(rows) {
+  const employeeNodes = [];
+  const employeesByName = new Map();
+  const placeholderManagers = new Map();
+
+  rows.forEach((row, index) => {
+    const label = row.name || `Employee ${index + 1}`;
+    const node = {
+      id: `emp-${index}`,
+      key: `${label}-${index}`,
+      label,
+      type: "employee",
+      data: row,
+      children: [],
+      originalChildren: [],
+      collapsed: false,
+      hasChildren: false,
+      isMatch: false,
+      visible: true,
+      searchTerms: buildSearchTerms(row, label),
+    };
+    employeeNodes.push(node);
+    const list = employeesByName.get(label) || [];
+    list.push(node);
+    employeesByName.set(label, list);
+  });
+
+  const getManagerNode = (name) => {
+    if (!name) return null;
+    const trimmed = name.trim();
+    if (!trimmed) return null;
+    const employeeList = employeesByName.get(trimmed);
+    if (employeeList && employeeList.length) {
+      return employeeList[0];
+    }
+    if (!placeholderManagers.has(trimmed)) {
+      const placeholder = {
+        id: `placeholder-${placeholderManagers.size}`,
+        key: trimmed,
+        label: trimmed,
+        type: "placeholder",
+        data: {
+          name: trimmed,
+          tribe: "",
+          squad: "",
+          expertise: "",
+          level: "",
+          manager: "",
+        },
+        children: [],
+        originalChildren: [],
+        collapsed: false,
+        hasChildren: false,
+        isMatch: false,
+        visible: true,
+        searchTerms: buildSearchTerms({ name: trimmed }, trimmed),
+      };
+      placeholderManagers.set(trimmed, placeholder);
+    }
+    return placeholderManagers.get(trimmed);
+  };
+
+  const roots = [];
+
+  employeeNodes.forEach((node) => {
+    const managerName = node.data.manager?.trim();
+    if (!managerName) {
+      roots.push(node);
+      return;
+    }
+    const managerNode = getManagerNode(managerName);
+    if (!managerNode) {
+      roots.push(node);
+      return;
+    }
+    if (managerNode === node) {
+      roots.push(node);
+      return;
+    }
+    managerNode.children.push(node);
+    node.parent = managerNode;
+  });
+
+  placeholderManagers.forEach((node) => {
+    if (!node.parent) {
+      roots.push(node);
+    }
+  });
+
+  const collapsedSet = state.search ? new Set() : state.collapsed;
+  const finalize = (node) => {
+    node.originalChildren = [...node.children];
+    node.hasChildren = node.originalChildren.length > 0;
+    if (collapsedSet.has(node.id)) {
+      node.children = [];
+      node.collapsed = true;
+    } else {
+      node.children = node.originalChildren.map(finalize);
+      node.collapsed = false;
+    }
+    return node;
+  };
+
+  return roots.map(finalize);
+}
+
+function buildTribeTree(rows) {
+  const tribeMap = new Map();
+
+  const getTribeNode = (tribeName) => {
+    const key = tribeName || "Unassigned Tribe";
+    if (!tribeMap.has(key)) {
+      tribeMap.set(key, {
+        id: `tribe-${key}`,
+        key,
+        label: key,
+        type: "tribe",
+        data: { tribe: key },
+        children: [],
+        originalChildren: [],
+        collapsed: false,
+        hasChildren: false,
+        isMatch: false,
+        visible: true,
+        searchTerms: buildSearchTerms({ tribe: key }, key),
+      });
+    }
+    return tribeMap.get(key);
+  };
+
+  const squadMap = new Map();
+  const getSquadNode = (tribeNode, squadName) => {
+    const key = `${tribeNode.key}__${squadName || "Unassigned Squad"}`;
+    if (!squadMap.has(key)) {
+      const label = squadName || "Unassigned Squad";
+      const node = {
+        id: `squad-${key}`,
+        key,
+        label,
+        type: "squad",
+        data: { tribe: tribeNode.label, squad: label },
+        children: [],
+        originalChildren: [],
+        collapsed: false,
+        hasChildren: false,
+        isMatch: false,
+        visible: true,
+        searchTerms: buildSearchTerms({ tribe: tribeNode.label, squad: label }, label),
+      };
+      squadMap.set(key, node);
+      tribeNode.children.push(node);
+      node.parent = tribeNode;
+    }
+    return squadMap.get(key);
+  };
+
+  rows.forEach((row) => {
+    const tribeNode = getTribeNode(row.tribe);
+    const squadNode = getSquadNode(tribeNode, row.squad);
+    const employeeNode = {
+      id: `emp-${row.name || crypto.randomUUID?.() || Math.random()}`,
+      key: row.name || Math.random().toString(36).slice(2),
+      label: row.name || "Unnamed",
+      type: "employee",
+      data: row,
+      children: [],
+      originalChildren: [],
+      collapsed: false,
+      hasChildren: false,
+      isMatch: false,
+      visible: true,
+      searchTerms: buildSearchTerms(row, row.name || "Unnamed"),
+      parent: squadNode,
+    };
+    squadNode.children.push(employeeNode);
+  });
+
+  const collapsedSet = state.search ? new Set() : state.collapsed;
+  const finalize = (node) => {
+    node.originalChildren = [...node.children];
+    node.hasChildren = node.originalChildren.length > 0;
+    if (collapsedSet.has(node.id)) {
+      node.children = [];
+      node.collapsed = true;
+    } else {
+      node.children = node.originalChildren.map(finalize);
+      node.collapsed = false;
+    }
+    return node;
+  };
+
+  return Array.from(tribeMap.values()).map(finalize);
+}
+
+function applySearch(roots, query) {
+  if (!query) {
+    const reset = (node) => {
+      node.isMatch = false;
+      node.visible = true;
+      node.children.forEach(reset);
+    };
+    roots.forEach(reset);
+    return roots;
+  }
+  const lower = query.toLowerCase();
+  const field = state.searchField || "all";
+
+  const getTerms = (node) => {
+    const terms = node.searchTerms;
+    if (!terms) return [];
+    if (field === "all") {
+      const allTerms = terms.all;
+      if (Array.isArray(allTerms)) return allTerms;
+      return allTerms ? [allTerms] : [];
+    }
+    const value = terms[field];
+    if (Array.isArray(value)) return value.filter(Boolean);
+    return value ? [value] : [];
+  };
+
+  const filterNode = (node) => {
+    const nodeTerms = getTerms(node);
+    const selfMatch = nodeTerms.some((term) => term.includes(lower));
+    const filteredChildren = node.children
+      .map(filterNode)
+      .filter((child) => child.visible);
+    node.children = filteredChildren;
+    node.isMatch = selfMatch;
+    node.visible = selfMatch || filteredChildren.length > 0;
+    return node;
+  };
+
+  return roots.map(filterNode).filter((node) => node.visible);
+}
+
+function computeLayout(roots) {
+  const positions = [];
+  const links = [];
+  let maxDepth = 0;
+
+  const subtreeWidth = (node) => {
+    if (!node.children || node.children.length === 0) {
+      node._width = 1;
+      return 1;
+    }
+    let width = 0;
+    node.children.forEach((child) => {
+      width += subtreeWidth(child);
+    });
+    node._width = Math.max(width, 1);
+    return node._width;
+  };
+
+  const place = (node, depth, offset) => {
+    const width = node._width || 1;
+    const xCenter = offset + (width - 1) / 2;
+    positions.push({ node, depth, x: xCenter });
+    maxDepth = Math.max(maxDepth, depth);
+    let childOffset = offset;
+    node.children.forEach((child) => {
+      place(child, depth + 1, childOffset);
+      links.push({ from: node, to: child });
+      childOffset += child._width || 1;
+    });
+  };
+
+  let offset = 0;
+  roots.forEach((root) => {
+    subtreeWidth(root);
+    place(root, 0, offset);
+    offset += root._width || 1;
+  });
+
+  const widthUnits = offset;
+  const widthPx = Math.max(widthUnits * HORIZONTAL_GAP, elements.chartContainer.clientWidth / state.scale);
+  const heightPx = Math.max((maxDepth + 1) * VERTICAL_GAP, elements.chartContainer.clientHeight / state.scale);
+
+  const positionMap = new Map();
+  positions.forEach((entry) => {
+    positionMap.set(entry.node, entry);
+  });
+
+  return {
+    nodes: positions,
+    nodePositions: positionMap,
+    links,
+    widthPx,
+    heightPx,
+  };
+}
+
+function renderNodes(layout) {
+  const { nodes, widthPx, heightPx } = layout;
+  const scaledWidth = Math.max(widthPx * state.scale, elements.chartContainer.clientWidth);
+  const scaledHeight = Math.max(heightPx * state.scale, elements.chartContainer.clientHeight);
+  elements.chartContent.style.width = `${scaledWidth}px`;
+  elements.chartContent.style.height = `${scaledHeight}px`;
+  elements.chartZoom.style.width = `${widthPx}px`;
+  elements.chartZoom.style.height = `${heightPx}px`;
+  elements.chartZoom.style.transform = `scale(${state.scale})`;
+  elements.chartNodes.innerHTML = "";
+
+  nodes.forEach(({ node, depth, x }) => {
+    const card = document.createElement("article");
+    card.classList.add("node-card");
+    if (node.type !== "employee") {
+      card.classList.add("group");
+    }
+    if (node.isMatch) {
+      card.classList.add("match");
+    }
+
+    const top = depth * VERTICAL_GAP + VERTICAL_GAP / 2 - NODE_HEIGHT / 2;
+    const left = x * HORIZONTAL_GAP + HORIZONTAL_GAP / 2 - NODE_WIDTH / 2;
+
+    card.style.transform = `translate(${left}px, ${top}px)`;
+
+    card.innerHTML = buildCardContent(node);
+
+    if (node.hasChildren) {
+      const toggle = document.createElement("button");
+      toggle.classList.add("collapse-toggle");
+      toggle.type = "button";
+      toggle.textContent = node.collapsed ? "+" : "−";
+      toggle.addEventListener("click", (event) => {
+        event.stopPropagation();
+        toggleNode(node);
+      });
+      card.appendChild(toggle);
+    }
+
+    card.addEventListener("click", () => {
+      if (node.hasChildren) {
+        toggleNode(node);
+      }
+    });
+
+    elements.chartNodes.appendChild(card);
+  });
+}
+
+function renderLinks(layout) {
+  const { links, nodePositions } = layout;
+  const svgNS = "http://www.w3.org/2000/svg";
+  elements.chartLinks.setAttribute("width", "100%");
+  elements.chartLinks.setAttribute("height", "100%");
+  elements.chartLinks.innerHTML = "";
+
+  links.forEach(({ from, to }) => {
+    const parentPos = nodePositions.get(from);
+    const childPos = nodePositions.get(to);
+    if (!parentPos || !childPos) return;
+
+    const startX = parentPos.x * HORIZONTAL_GAP + HORIZONTAL_GAP / 2;
+    const startY = parentPos.depth * VERTICAL_GAP + VERTICAL_GAP / 2 + NODE_HEIGHT / 2;
+    const endX = childPos.x * HORIZONTAL_GAP + HORIZONTAL_GAP / 2;
+    const endY = childPos.depth * VERTICAL_GAP + VERTICAL_GAP / 2 - NODE_HEIGHT / 2;
+    const controlY = (startY + endY) / 2;
+
+    const path = document.createElementNS(svgNS, "path");
+    path.setAttribute(
+      "d",
+      `M${startX},${startY} C ${startX},${controlY} ${endX},${controlY} ${endX},${endY}`
+    );
+    path.setAttribute("fill", "none");
+    path.setAttribute("stroke", "rgba(148, 163, 184, 0.5)");
+    path.setAttribute("stroke-width", "2");
+    elements.chartLinks.appendChild(path);
+  });
+}
+
+function toggleNode(node) {
+  if (state.search) return; // disable toggling while filtering
+  if (state.collapsed.has(node.id)) {
+    state.collapsed.delete(node.id);
+  } else {
+    state.collapsed.add(node.id);
+  }
+  render();
+}
+
+function drawMinimap(layout) {
+  const ctx = elements.minimap.getContext("2d");
+  ctx.clearRect(0, 0, elements.minimap.width, elements.minimap.height);
+
+  if (!layout || !layout.nodes.length) {
+    ctx.fillStyle = "rgba(148, 163, 184, 0.3)";
+    ctx.font = "12px Inter, sans-serif";
+    ctx.textAlign = "center";
+    ctx.fillText("No data", elements.minimap.width / 2, elements.minimap.height / 2);
+    return;
+  }
+
+  const { widthPx, heightPx } = layout;
+  const { scale, offsetX, offsetY } = getMinimapScaling(widthPx, heightPx);
+
+  ctx.save();
+  ctx.translate(offsetX, offsetY);
+  ctx.scale(scale, scale);
+
+  ctx.strokeStyle = "rgba(148, 163, 184, 0.35)";
+  ctx.lineWidth = 1 / scale;
+  layout.links.forEach(({ from, to }) => {
+    const parentPos = layout.nodePositions.get(from);
+    const childPos = layout.nodePositions.get(to);
+    if (!parentPos || !childPos) return;
+    const startX = parentPos.x * HORIZONTAL_GAP + HORIZONTAL_GAP / 2;
+    const startY = parentPos.depth * VERTICAL_GAP + VERTICAL_GAP / 2;
+    const endX = childPos.x * HORIZONTAL_GAP + HORIZONTAL_GAP / 2;
+    const endY = childPos.depth * VERTICAL_GAP + VERTICAL_GAP / 2;
+    ctx.beginPath();
+    ctx.moveTo(startX, startY);
+    ctx.lineTo(endX, endY);
+    ctx.stroke();
+  });
+
+  layout.nodes.forEach(({ node, depth, x }) => {
+    const cx = x * HORIZONTAL_GAP + HORIZONTAL_GAP / 2;
+    const cy = depth * VERTICAL_GAP + VERTICAL_GAP / 2;
+    ctx.fillStyle = node.type === "employee" ? "#2563eb" : "#0ea5e9";
+    ctx.fillRect(cx - 6, cy - 6, 12, 12);
+  });
+
+  ctx.restore();
+
+  // viewport rectangle
+  const visibleWidth = elements.chartContainer.clientWidth / state.scale;
+  const visibleHeight = elements.chartContainer.clientHeight / state.scale;
+  const scrollLeft = elements.chartContainer.scrollLeft / state.scale;
+  const scrollTop = elements.chartContainer.scrollTop / state.scale;
+
+  ctx.save();
+  ctx.translate(offsetX, offsetY);
+  ctx.scale(scale, scale);
+  ctx.strokeStyle = "rgba(37, 99, 235, 0.8)";
+  ctx.lineWidth = 1 / scale;
+  ctx.strokeRect(scrollLeft, scrollTop, visibleWidth, visibleHeight);
+  ctx.restore();
+}
+
+function getMinimapScaling(widthPx, heightPx) {
+  const padding = 16;
+  const maxWidth = elements.minimap.width - padding * 2;
+  const maxHeight = elements.minimap.height - padding * 2;
+  const scale = Math.min(maxWidth / widthPx, maxHeight / heightPx, 1);
+  const offsetX = (elements.minimap.width - widthPx * scale) / 2;
+  const offsetY = (elements.minimap.height - heightPx * scale) / 2;
+  return { scale, offsetX, offsetY };
+}
+
+function mapRows(rawRows) {
+  return rawRows
+    .map((row) => normalizeRow(row))
+    .filter((row) => row.name);
+}
+
+function normalizeRow(row) {
+  const normalized = {};
+  Object.entries(row).forEach(([key, value]) => {
+    normalized[normalizeColumnName(key)] = typeof value === "string" ? value.trim() : value;
+  });
+
+  const result = {
+    name: pickAlias(normalized, "name"),
+    tribe: pickAlias(normalized, "tribe"),
+    squad: pickAlias(normalized, "squad"),
+    expertise: pickAlias(normalized, "expertise"),
+    level: pickAlias(normalized, "level"),
+    manager: pickAlias(normalized, "manager"),
+  };
+
+  return Object.fromEntries(
+    Object.entries(result).map(([key, value]) => [key, typeof value === "string" ? value.trim() : value])
+  );
+}
+
+function pickAlias(row, field) {
+  const aliases = COLUMN_ALIASES[field] || [];
+  for (const alias of aliases) {
+    if (row.hasOwnProperty(alias)) {
+      return row[alias];
+    }
+  }
+  return row[field] ?? "";
+}
+
+function normalizeColumnName(name) {
+  return name
+    .toLowerCase()
+    .replace(/[_-]+/g, " ")
+    .replace(/[^a-z0-9 ]+/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function buildSearchTerms(row, fallback) {
+  const normalize = (value) =>
+    typeof value === "string" ? value.trim().toLowerCase() : "";
+
+  const fallbackValue = normalize(fallback);
+  const name = normalize(row.name) || fallbackValue;
+  const tribe = normalize(row.tribe);
+  const squad = normalize(row.squad);
+  const expertise = normalize(row.expertise);
+  const level = normalize(row.level);
+  const manager = normalize(row.manager);
+
+  const all = [fallbackValue, name, tribe, squad, expertise, level, manager].filter(Boolean);
+
+  return {
+    all: Array.from(new Set(all)),
+    name,
+    tribe,
+    squad,
+    expertise,
+    level,
+    manager,
+  };
+}
+
+function buildCardContent(node) {
+  if (node.type === "tribe") {
+    return `
+      <h3 class="title">${escapeHtml(node.label)}</h3>
+      <p class="meta">Tribe · ${node.originalChildren.length} squads</p>
+    `;
+  }
+  if (node.type === "squad") {
+    return `
+      <div class="badge">Squad</div>
+      <h3 class="title">${escapeHtml(node.label)}</h3>
+      <p class="meta">${node.originalChildren.length} people · ${escapeHtml(node.data.tribe)}</p>
+    `;
+  }
+  if (node.type === "placeholder") {
+    return `
+      <div class="badge">Manager</div>
+      <h3 class="title">${escapeHtml(node.label)}</h3>
+      <p class="meta">${node.originalChildren.length} direct reports</p>
+    `;
+  }
+
+  const { expertise, tribe, squad, level, manager } = node.data;
+  const teamLine = [tribe, squad].filter(Boolean).map(escapeHtml).join(" · ");
+  return `
+    <div class="badge">${escapeHtml(level || "Employee")}</div>
+    <h3 class="title">${escapeHtml(node.label)}</h3>
+    <p class="meta">
+      <span>${escapeHtml(expertise || "")}</span>
+      ${teamLine ? `<span>${teamLine}</span>` : ""}
+      <span>Manager: ${escapeHtml(manager || "–")}</span>
+    </p>
+  `;
+}
+
+function toggleLoader(active) {
+  elements.chartContainer.classList.toggle("loading", active);
+}
+
+function updateStatus(message, isError = false) {
+  elements.statusMessage.textContent = message;
+  elements.statusBar.style.color = isError ? "#ef4444" : "var(--color-subtle)";
+}
+
+function escapeHtml(value) {
+  if (value == null) return "";
+  return value
+    .toString()
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+function extractGoogleSheetId(url) {
+  const patterns = [
+    /spreadsheets\/d\/([a-zA-Z0-9-_]+)/,
+    /spreadsheets\?id=([a-zA-Z0-9-_]+)/,
+  ];
+  for (const pattern of patterns) {
+    const match = url.match(pattern);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+function parseCsv(text) {
+  const lines = text.split(/\r?\n/).filter(Boolean);
+  if (!lines.length) return [];
+  const headers = splitCsvLine(lines[0]);
+  return lines.slice(1).map((line) => {
+    const cells = splitCsvLine(line);
+    const row = {};
+    headers.forEach((header, index) => {
+      row[header] = cells[index] ?? "";
+    });
+    return row;
+  });
+}
+
+function splitCsvLine(line) {
+  const result = [];
+  let current = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const char = line[i];
+    if (char === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        current += '"';
+        i += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (char === "," && !inQuotes) {
+      result.push(current);
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  result.push(current);
+  return result.map((value) => value.trim());
+}
+
+function updateViewModeUI() {
+  elements.viewToggleButtons.forEach((button) => {
+    const isActive = button.dataset.viewMode === state.view;
+    button.classList.toggle("is-active", isActive);
+    button.setAttribute("aria-pressed", String(isActive));
+  });
+}
+
+function updateSearchScopeUI() {
+  elements.searchFilterChips.forEach((chip) => {
+    const isActive = chip.dataset.searchField === state.searchField;
+    chip.classList.toggle("is-active", isActive);
+    chip.setAttribute("aria-pressed", String(isActive));
+  });
+}
+
+function updateSearchPlaceholder() {
+  const placeholder = SEARCH_PLACEHOLDERS[state.searchField] || SEARCH_PLACEHOLDERS.all;
+  elements.searchInput.placeholder = placeholder;
+  elements.searchInput.setAttribute("aria-label", placeholder);
+}
+
+function updateClearButton() {
+  elements.clearSearch.disabled = !state.search;
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function updateThemeButton(theme) {
+  const icon = elements.themeToggle.querySelector(".icon");
+  if (icon) {
+    icon.textContent = theme === "dark" ? "☀️" : "🌙";
+  }
+  elements.themeToggle.setAttribute("aria-pressed", theme === "dark" ? "true" : "false");
+}
+
+// initial render with sample data for a quick start
+if (!state.rows.length) {
+  state.rows = [...SAMPLE_DATA];
+  render();
+  updateStatus("Showing sample data. Upload a file to replace.");
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Organizational Chart Explorer</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/xlsx@0.19.3/dist/xlsx.full.min.js" defer></script>
+    <script src="app.js" type="module" defer></script>
+  </head>
+  <body>
+    <div class="app">
+      <header class="control-panel">
+        <div class="control-header">
+          <div class="data-actions">
+            <label class="ingest-button" for="file-input">
+              <span class="icon" aria-hidden="true">⬆️</span>
+              <span>Upload .xlsx</span>
+            </label>
+            <input type="file" accept=".xlsx,.xlsm" id="file-input" />
+            <button id="load-sample" type="button" class="secondary-button">Sample data</button>
+            <div class="link-field">
+              <input
+                type="url"
+                id="sheet-url"
+                placeholder="Paste Google Sheets link"
+                autocomplete="off"
+              />
+              <button id="load-sheet" type="button" class="secondary-button">Import</button>
+            </div>
+          </div>
+          <div class="view-switch" role="group" aria-label="View mode">
+            <button type="button" class="segmented-option" data-view-mode="manager">
+              Manager based
+            </button>
+            <button type="button" class="segmented-option" data-view-mode="tribe">
+              Tribe based
+            </button>
+          </div>
+          <button id="theme-toggle" type="button" class="tone-button" title="Toggle dark mode">
+            <span class="icon" aria-hidden="true">🌙</span>
+            <span class="sr-only">Toggle dark mode</span>
+          </button>
+        </div>
+        <div class="search-row">
+          <div class="search-bar">
+            <span class="icon" aria-hidden="true">🔍</span>
+            <input
+              type="search"
+              id="search-input"
+              placeholder="Search employees, tribes, squads, expertise, job levels or managers"
+              autocomplete="off"
+            />
+            <button id="clear-search" type="button" class="tone-button" title="Clear search">
+              <span aria-hidden="true">✕</span>
+              <span class="sr-only">Clear search</span>
+            </button>
+          </div>
+          <div
+            class="filter-row"
+            id="search-filter-group"
+            role="radiogroup"
+            aria-label="Search scope"
+          >
+            <button type="button" class="filter-chip" data-search-field="all" aria-pressed="true">
+              All
+            </button>
+            <button type="button" class="filter-chip" data-search-field="name">Employee</button>
+            <button type="button" class="filter-chip" data-search-field="tribe">Tribe</button>
+            <button type="button" class="filter-chip" data-search-field="squad">Squad</button>
+            <button type="button" class="filter-chip" data-search-field="expertise">Expertise</button>
+            <button type="button" class="filter-chip" data-search-field="level">Job level</button>
+            <button type="button" class="filter-chip" data-search-field="manager">Manager</button>
+          </div>
+        </div>
+      </header>
+
+      <main class="workspace">
+        <div class="chart-shell">
+          <div class="chart-stage">
+            <div id="chart-container">
+              <div id="chart-content">
+                <div id="chart-zoom">
+                  <svg id="chart-links"></svg>
+                  <div id="chart-nodes"></div>
+                </div>
+              </div>
+            </div>
+            <div class="empty-state" id="empty-state">
+              <h2>Upload a spreadsheet to get started</h2>
+              <p>
+                Use the sample data or drop in your own file with columns for employee name, tribe,
+                squad, expertise, job level and manager name.
+              </p>
+            </div>
+          </div>
+          <div class="fab" id="fab">
+            <button class="fab-button" data-action="expand" title="Expand all">⤦</button>
+            <button class="fab-button" data-action="collapse" title="Collapse all">⤣</button>
+            <button class="fab-button" data-action="zoom-in" title="Zoom in">＋</button>
+            <button class="fab-button" data-action="zoom-out" title="Zoom out">−</button>
+            <button class="fab-button" data-action="zoom-fit" title="Zoom to fit">⤢</button>
+          </div>
+          <aside class="minimap-card">
+            <div class="minimap-header">
+              <span>Mini map</span>
+              <p>Click to navigate</p>
+            </div>
+            <canvas
+              id="minimap"
+              width="200"
+              height="160"
+              role="img"
+              aria-label="Organizational chart overview"
+            ></canvas>
+          </aside>
+        </div>
+      </main>
+
+      <footer class="status-bar" id="status-bar">
+        <span id="status-message">No data loaded</span>
+      </footer>
+    </div>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,600 @@
+:root {
+  --color-page: #e9ecff;
+  --color-bg: #f6f7ff;
+  --color-surface: #ffffff;
+  --color-surface-alt: rgba(255, 255, 255, 0.8);
+  --color-surface-muted: #eef1ff;
+  --color-text: #1c2038;
+  --color-subtle: #6c7396;
+  --color-accent: #6366f1;
+  --color-border: #d6dcf3;
+  --color-border-strong: #c1c7ea;
+  --color-card-shadow: rgba(88, 101, 173, 0.16);
+  --color-card-shadow-strong: rgba(88, 101, 173, 0.26);
+  --color-fab-bg: rgba(255, 255, 255, 0.92);
+  --color-fab-border: rgba(99, 102, 241, 0.18);
+  --color-success: #22d3ee;
+}
+
+[data-theme="dark"] {
+  --color-page: #0b1224;
+  --color-bg: #111a33;
+  --color-surface: #121a2e;
+  --color-surface-alt: rgba(18, 26, 46, 0.85);
+  --color-surface-muted: rgba(27, 38, 61, 0.85);
+  --color-text: #f1f5ff;
+  --color-subtle: #98a2c3;
+  --color-accent: #8b5cf6;
+  --color-border: rgba(148, 163, 184, 0.25);
+  --color-border-strong: rgba(148, 163, 184, 0.35);
+  --color-card-shadow: rgba(10, 12, 28, 0.6);
+  --color-card-shadow-strong: rgba(10, 12, 28, 0.75);
+  --color-fab-bg: rgba(17, 24, 39, 0.88);
+  --color-fab-border: rgba(139, 92, 246, 0.25);
+  --color-success: #38bdf8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: linear-gradient(160deg, var(--color-page) 0%, var(--color-bg) 45%, #fdfdff 100%);
+  color: var(--color-text);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+}
+
+button,
+label {
+  font: inherit;
+  cursor: pointer;
+}
+
+.app {
+  width: min(1400px, 100%);
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  min-height: 100vh;
+}
+
+.control-panel {
+  background: var(--color-surface-alt);
+  backdrop-filter: blur(14px);
+  border-radius: clamp(1.2rem, 2vw, 2rem);
+  border: 1px solid var(--color-border);
+  padding: clamp(1.2rem, 2vw, 1.8rem);
+  box-shadow: 0 30px 80px -60px var(--color-card-shadow-strong);
+}
+
+.control-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: clamp(1rem, 2vw, 1.8rem);
+  align-items: center;
+}
+
+.data-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.data-actions input[type="file"] {
+  display: none;
+}
+
+.ingest-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  border: 1px dashed var(--color-border-strong);
+  background: var(--color-surface);
+  color: var(--color-accent);
+  font-weight: 600;
+  transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+}
+
+.ingest-button:hover,
+.ingest-button:focus-visible {
+  border-color: var(--color-accent);
+  background: var(--color-surface-muted);
+}
+
+.secondary-button {
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text);
+  border-radius: 999px;
+  padding: 0.55rem 0.95rem;
+  font-weight: 500;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.secondary-button:hover,
+.secondary-button:focus-visible {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  background: var(--color-surface-muted);
+}
+
+.link-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.3rem 0.3rem 0.3rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+}
+
+.link-field input {
+  border: none;
+  background: transparent;
+  color: var(--color-text);
+  min-width: 200px;
+  font-size: 0.95rem;
+}
+
+.link-field input::placeholder {
+  color: var(--color-subtle);
+}
+
+.link-field input:focus-visible {
+  outline: none;
+}
+
+.view-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem;
+  border-radius: 999px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.segmented-option {
+  border: none;
+  background: transparent;
+  color: var(--color-subtle);
+  font-weight: 600;
+  padding: 0.45rem 1.15rem;
+  border-radius: 999px;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.segmented-option.is-active {
+  background: var(--color-accent);
+  color: #ffffff;
+  box-shadow: 0 12px 20px -16px rgba(99, 102, 241, 0.5);
+}
+
+.tone-button {
+  width: 2.6rem;
+  height: 2.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.tone-button:hover,
+.tone-button:focus-visible {
+  background: var(--color-surface-muted);
+  border-color: var(--color-accent);
+}
+
+.tone-button:active {
+  transform: scale(0.95);
+}
+
+.tone-button[disabled] {
+  opacity: 0.45;
+  cursor: default;
+  transform: none;
+}
+
+.search-row {
+  margin-top: clamp(1.2rem, 2vw, 1.8rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.search-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  padding: 0.35rem 0.35rem 0.35rem 1rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.search-bar input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-size: 1rem;
+  color: var(--color-text);
+}
+
+.search-bar input::placeholder {
+  color: var(--color-subtle);
+}
+
+.search-bar input:focus-visible {
+  outline: none;
+}
+
+.filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.filter-chip {
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-subtle);
+  border-radius: 999px;
+  padding: 0.4rem 0.95rem;
+  font-weight: 500;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.filter-chip.is-active {
+  background: var(--color-accent);
+  color: #ffffff;
+  border-color: transparent;
+  box-shadow: 0 10px 20px -15px rgba(99, 102, 241, 0.6);
+}
+
+.workspace {
+  flex: 1;
+  display: flex;
+}
+
+.chart-shell {
+  flex: 1;
+  position: relative;
+  background: var(--color-surface);
+  border-radius: clamp(1.5rem, 3vw, 2.2rem);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 35px 90px -70px var(--color-card-shadow-strong);
+  padding: clamp(1.5rem, 2.5vw, 2.5rem);
+  display: flex;
+  flex-direction: column;
+}
+
+.chart-stage {
+  position: relative;
+  flex: 1;
+  border-radius: clamp(1.2rem, 2.5vw, 1.8rem);
+  border: 1px solid var(--color-border);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.8) 0%, var(--color-surface-muted) 100%);
+  overflow: hidden;
+  display: flex;
+}
+
+[data-theme="dark"] .chart-stage {
+  background: linear-gradient(180deg, rgba(30, 41, 59, 0.88) 0%, rgba(15, 23, 42, 0.88) 100%);
+}
+
+#chart-container {
+  flex: 1;
+  position: relative;
+  overflow: auto;
+  padding: clamp(1.5rem, 2vw, 2rem);
+}
+
+#chart-content {
+  position: relative;
+  min-width: 100%;
+  min-height: 100%;
+}
+
+#chart-zoom {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform-origin: top left;
+  width: 100%;
+  height: 100%;
+}
+
+#chart-links {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  pointer-events: none;
+}
+
+#chart-nodes {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.node-card {
+  position: absolute;
+  width: 220px;
+  min-height: 120px;
+  background: var(--color-surface);
+  border-radius: 1.2rem;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 20px 40px -30px var(--color-card-shadow-strong);
+  padding: 1rem 1.1rem;
+  transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+}
+
+.node-card:hover,
+.node-card:focus-within {
+  border-color: var(--color-accent);
+  box-shadow: 0 30px 50px -35px rgba(99, 102, 241, 0.45);
+  transform: translateY(-2px);
+}
+
+.node-card.group {
+  background: rgba(99, 102, 241, 0.08);
+  border-color: rgba(99, 102, 241, 0.25);
+}
+
+.node-card .title {
+  font-weight: 600;
+  font-size: 1rem;
+  margin: 0;
+}
+
+.node-card .meta {
+  margin: 0.5rem 0 0;
+  color: var(--color-subtle);
+  font-size: 0.85rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.node-card .badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.15);
+  color: var(--color-accent);
+  font-weight: 600;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.node-card .collapse-toggle {
+  position: absolute;
+  top: 0.45rem;
+  right: 0.45rem;
+  border: none;
+  background: rgba(15, 23, 42, 0.06);
+  color: inherit;
+  border-radius: 0.6rem;
+  width: 1.6rem;
+  height: 1.6rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+[data-theme="dark"] .node-card .collapse-toggle {
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.node-card .collapse-toggle:hover {
+  background: rgba(99, 102, 241, 0.18);
+}
+
+.node-card.match {
+  border-color: var(--color-success);
+  box-shadow: 0 0 0 3px rgba(34, 211, 238, 0.35), 0 25px 45px -35px var(--color-card-shadow-strong);
+}
+
+.empty-state {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.8rem;
+  text-align: center;
+  padding: 2.5rem;
+  color: var(--color-subtle);
+}
+
+.empty-state h2 {
+  color: var(--color-text);
+  margin-bottom: 0.2rem;
+}
+
+.fab {
+  position: absolute;
+  left: 50%;
+  bottom: clamp(1.2rem, 2vw, 1.8rem);
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  background: var(--color-fab-bg);
+  border: 1px solid var(--color-fab-border);
+  box-shadow: 0 30px 60px -45px var(--color-card-shadow-strong);
+  backdrop-filter: blur(12px);
+}
+
+.fab-button {
+  width: 2.6rem;
+  height: 2.6rem;
+  border-radius: 50%;
+  border: none;
+  background: var(--color-accent);
+  color: #ffffff;
+  font-weight: 700;
+  font-size: 1.05rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.fab-button:hover,
+.fab-button:focus-visible {
+  transform: translateY(-1px);
+  background: #4f46e5;
+}
+
+.fab-button:active {
+  transform: translateY(0);
+}
+
+.minimap-card {
+  position: absolute;
+  right: clamp(1.2rem, 2vw, 1.8rem);
+  bottom: clamp(1.2rem, 2vw, 1.8rem);
+  width: 220px;
+  padding: 1rem;
+  border-radius: 1.1rem;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  box-shadow: 0 20px 50px -40px var(--color-card-shadow-strong);
+  backdrop-filter: blur(12px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.minimap-header span {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.minimap-header p {
+  margin: 0.2rem 0 0;
+  font-size: 0.8rem;
+  color: var(--color-subtle);
+}
+
+#minimap {
+  width: 100%;
+  height: auto;
+  border-radius: 0.8rem;
+  border: 1px solid var(--color-border);
+  background: rgba(255, 255, 255, 0.7);
+}
+
+[data-theme="dark"] #minimap {
+  background: rgba(15, 23, 42, 0.85);
+}
+
+.status-bar {
+  border-radius: clamp(1rem, 2vw, 1.5rem);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  padding: 0.9rem 1.2rem;
+  font-size: 0.9rem;
+  color: var(--color-subtle);
+  backdrop-filter: blur(12px);
+  display: flex;
+  justify-content: space-between;
+}
+
+.icon {
+  font-size: 1.05rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+button:focus-visible,
+.filter-chip:focus-visible,
+.ingest-button:focus-visible,
+.secondary-button:focus-visible {
+  outline: 2px solid rgba(99, 102, 241, 0.65);
+  outline-offset: 2px;
+}
+
+@media (max-width: 1024px) {
+  .control-header {
+    grid-template-columns: 1fr;
+    align-items: flex-start;
+  }
+
+  .view-switch {
+    justify-self: flex-start;
+  }
+
+  .workspace {
+    padding-bottom: 5rem;
+  }
+
+  .fab {
+    bottom: 1.2rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .app {
+    padding: 1.25rem;
+  }
+
+  .data-actions {
+    gap: 0.6rem;
+  }
+
+  .link-field input {
+    min-width: 140px;
+  }
+
+  .chart-shell {
+    padding: 1.25rem;
+  }
+
+  #chart-container {
+    padding: 1.25rem;
+  }
+
+  .minimap-card {
+    position: static;
+    width: 100%;
+    margin-top: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- rebuild the page shell with a glassmorphism-inspired control panel, segmented view toggle, scoped search chips, and repositioned minimap and FAB controls
- refresh styles to deliver the requested light/dark theme, centered chart stage, horizontal action bar, and minimap card presentation
- enhance client logic with scoped search placeholders, segmented toggle handling, accessible theme switching, and cleaned reset behaviour

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e646d61f50832da4d6a4cb3ceadb48